### PR TITLE
feat(cli): pull docket sample from courtlistener api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ ALLOWED_HOSTS="*"
 ## Uncomment for DEBUG mode
 #DEBUG=on
 
+# Configure CourtListener
+
+#CL_TOKEN=""
+
 
 # Configure HuggingFace
 


### PR DESCRIPTION
Adds to the `generate-docket-sample` command to pull the docket sample from CL API. Uses the search endpoint with type=rd. We use a 0.5s sleep between requests, 30 second sleep between retries, up to 3 retries per request. Will take about 4 days if run uninterrupted (though we'll probably need to resume a few times).

Fixes: #17